### PR TITLE
fix deposit cancel lock and redeem balance drift

### DIFF
--- a/src/interfaces/managers/IRiskManager.sol
+++ b/src/interfaces/managers/IRiskManager.sol
@@ -97,6 +97,9 @@ interface IRiskManager is IFactoryEntity {
     /// @notice Modifies the vault's internal balance by a signed delta (in asset terms)
     function modifyVaultBalance(address asset, int256 delta) external;
 
+    /// @notice Modifies the vault's internal balance by a signed delta (in share terms)
+    function modifyVaultBalanceShares(int256 shares) external;
+
     /// @notice Modifies a subvault's internal balance by a signed delta (in asset terms)
     function modifySubvaultBalance(address subvault, address asset, int256 delta) external;
 

--- a/src/managers/RiskManager.sol
+++ b/src/managers/RiskManager.sol
@@ -209,8 +209,17 @@ contract RiskManager is IRiskManager, ContextUpgradeable {
         int256 pendingAssetsBefore = $.pendingAssets[asset];
         int256 pendingSharesBefore = $.pendingShares[asset];
         int256 pendingAssetsAfter = pendingAssetsBefore + change;
-        int256 pendingSharesAfter = convertToShares(asset, pendingAssetsAfter);
-        int256 shares = pendingSharesAfter - pendingSharesBefore;
+
+        int256 shares;
+        int256 pendingSharesAfter;
+        if (change < 0 && pendingAssetsBefore > 0 && !_hasValidReport(asset)) {
+            shares = change * pendingSharesBefore / pendingAssetsBefore;
+            pendingSharesAfter = pendingSharesBefore + shares;
+        } else {
+            pendingSharesAfter = convertToShares(asset, pendingAssetsAfter);
+            shares = pendingSharesAfter - pendingSharesBefore;
+        }
+
         int256 newPendingBalance = $.pendingBalance + shares;
         if (change > 0 && $.vaultState.balance + newPendingBalance > $.vaultState.limit) {
             revert LimitExceeded($.vaultState.balance + newPendingBalance, $.vaultState.limit);
@@ -224,13 +233,12 @@ contract RiskManager is IRiskManager, ContextUpgradeable {
     /// @inheritdoc IRiskManager
     function modifyVaultBalance(address asset, int256 change) external onlyQueueOrRole(MODIFY_VAULT_BALANCE_ROLE) {
         int256 shares = convertToShares(asset, change);
-        RiskManagerStorage storage $ = _riskManagerStorage();
-        int256 newBalance = $.vaultState.balance + shares;
-        if (change > 0 && newBalance + $.pendingBalance > $.vaultState.limit) {
-            revert LimitExceeded(newBalance + $.pendingBalance, $.vaultState.limit);
-        }
-        $.vaultState.balance = newBalance;
-        emit ModifyVaultBalance(asset, shares, newBalance);
+        _applyVaultBalanceChange(asset, shares);
+    }
+
+    /// @inheritdoc IRiskManager
+    function modifyVaultBalanceShares(int256 shares) external onlyQueueOrRole(MODIFY_VAULT_BALANCE_ROLE) {
+        _applyVaultBalanceChange(address(0), shares);
     }
 
     /// @inheritdoc IRiskManager
@@ -254,6 +262,22 @@ contract RiskManager is IRiskManager, ContextUpgradeable {
     }
 
     // Internal functions
+
+    function _hasValidReport(address asset) internal view returns (bool) {
+        RiskManagerStorage storage $ = _riskManagerStorage();
+        IOracle.DetailedReport memory report = IShareModule($.vault).oracle().getReport(asset);
+        return !report.isSuspicious && report.priceD18 != 0;
+    }
+
+    function _applyVaultBalanceChange(address asset, int256 shares) internal {
+        RiskManagerStorage storage $ = _riskManagerStorage();
+        int256 newBalance = $.vaultState.balance + shares;
+        if (shares > 0 && newBalance + $.pendingBalance > $.vaultState.limit) {
+            revert LimitExceeded(newBalance + $.pendingBalance, $.vaultState.limit);
+        }
+        $.vaultState.balance = newBalance;
+        emit ModifyVaultBalance(asset, shares, newBalance);
+    }
 
     function _riskManagerStorage() internal view returns (RiskManagerStorage storage $) {
         bytes32 slot = _riskManagerStorageSlot;

--- a/src/queues/RedeemQueue.sol
+++ b/src/queues/RedeemQueue.sol
@@ -195,7 +195,7 @@ contract RedeemQueue is IRedeemQueue, Queue {
         if (counter > 0) {
             if (demand > 0) {
                 vault_.callHook(demand);
-                IVaultModule(address(vault_)).riskManager().modifyVaultBalance(asset(), -int256(uint256(demand)));
+                IVaultModule(address(vault_)).riskManager().modifyVaultBalanceShares(-int256(shares));
                 $.totalDemandAssets -= demand;
             }
             $.batchIterator += counter;


### PR DESCRIPTION
hey team, its moondev, checked the codebase and found 2 issues around risk manager accounting, not sure if helpful

first one is cancelDepositRequest on the async deposit queue. when the oracle marks a report suspicious, modifyPendingAssets still calls convertToShares on the live oracle and reverts with InvalidReport. so users with a pending deposit cant cancel and get their assets back until someone accepts the report. the fix uses the stored pendingAssets/pendingShares ratio for negative changes when the report is invalid, so cancellation still works during review

second one is RedeemQueue handleBatches. batches store shares burned at report price, but modifyVaultBalance was re-converting the asset demand at the current oracle price. if price moved up between report and batch handling, vaultState.balance got debited too hard and could go negative, which makes maxDeposit return more than the risk limit should allow. now it debits by the batch share amount directly via modifyVaultBalanceShares

cheers